### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/portscript/d348ea2c-06c5-4aa4-9aac-f0d2f4880f7b/4b4a2ea8-2647-4b03-8172-b72e0232d695/_apis/work/boardbadge/477cf838-3a52-4190-9a10-6e40fa706197)](https://dev.azure.com/portscript/d348ea2c-06c5-4aa4-9aac-f0d2f4880f7b/_boards/board/t/4b4a2ea8-2647-4b03-8172-b72e0232d695/Microsoft.RequirementCategory)
 # FullStackProjects
 Simple projects made as part of my learning


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/portscript/d348ea2c-06c5-4aa4-9aac-f0d2f4880f7b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.